### PR TITLE
refactor: return errors in array property

### DIFF
--- a/src/models/CPAlgorithmTrait.php
+++ b/src/models/CPAlgorithmTrait.php
@@ -15,10 +15,15 @@ trait CPAlgorithmTrait
         return $this->algorithms->algorithms;
     }
 
-	public function getAlgorithmsLastError()
-	{
-		return $this->client->getLastError();
-	}
+    public function getAlgorithmsLastError()
+    {
+        $lastError = $this->client->getLastError();
+        if ($lastError != null && property_exists($lastError, 'error')) {
+            $lastError->errors = $lastError->error;
+            unset($lastError->error);
+        }
+        return $lastError;
+    }
 
     public function algorithms()
     {


### PR DESCRIPTION
"We need to update the error handling for all the prediction methods in all plugins because ai core has two different error responses, one with error as an object and once errors as array of strings" (355)